### PR TITLE
README.md: Re-generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## jist.el
-*Manage gists from emacs -*- lexical-binding: t; -*-*
+*Manage gists from Emacs -*- lexical-binding: t; -*-*
 
 ---
-[![Travis build status](https://travis-ci.org/emacs-pe/jist.el.png?branch=master)](https://travis-ci.org/emacs-pe/jist.el)
+[![License GPLv3](https://img.shields.io/badge/license-GPL_v3-green.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
+[![Build Status](https://travis-ci.org/emacs-pe/jist.el.svg?branch=master)](https://travis-ci.org/emacs-pe/jist.el)
+[![MELPA](http://melpa.org/packages/jist-badge.svg)](http://melpa.org/#/jist)
 
 Yet another [gist][] client for Emacs.
 

--- a/jist.el
+++ b/jist.el
@@ -26,7 +26,6 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; [![Travis build status](https://travis-ci.org/emacs-pe/jist.el.png?branch=master)](https://travis-ci.org/emacs-pe/jist.el)
 ;;
 ;; Yet another [gist][] client for Emacs.
 ;;


### PR DESCRIPTION
`make-readme-markdown` has recently gained the ability to add a license badge to your `README.md` if a license can be detected.  Here's how it looks.
